### PR TITLE
TOK-897: invalidate on reorg

### DIFF
--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -1,10 +1,10 @@
 import log from 'loglevel';
 
+import { getConfig } from '../config/config';
+import { createContexts } from '../context/create';
 import { createDb } from '../handlers/dbCreator';
 import { syncEntities } from '../handlers/subgraphSyncer';
-import { getConfig } from '../config/config';
 import { watchBlocks } from '../watchers/blockWatcher';
-import { createContexts } from '../context/create';
 
 const main = async () => {
   try {

--- a/src/handlers/dbCreator.ts
+++ b/src/handlers/dbCreator.ts
@@ -1,9 +1,9 @@
+import { Knex } from 'knex';
 import log from 'loglevel';
 import { App, Column, Entity } from '../config/types';
-import { columnTypeMap, isColumnType, isArrayColumnType, ColumnType } from './types';
-import { AppContext } from '../context/types';
-import { Knex } from 'knex';
 import { DatabaseSchema } from '../context/schema';
+import { AppContext } from '../context/types';
+import { ColumnType, columnTypeMap, isArrayColumnType, isColumnType } from './types';
 
 const getReferencedIdColumnType = (schema: DatabaseSchema, column: Column): ColumnType[] => {
     const referencedEntity = schema.entities.get(column.type);
@@ -127,4 +127,4 @@ const getExistingTables = async (db: Knex): Promise<string[]> => {
     return result.map((row) => row.table_name);
 }
 
-export { createDb }
+export { createDb };

--- a/src/watchers/blockWatcher.ts
+++ b/src/watchers/blockWatcher.ts
@@ -1,11 +1,12 @@
 // blockWatcher.ts
-import { PublicClient, type Block } from 'viem'
 import log from 'loglevel';
+import { PublicClient, type Block } from 'viem';
 
-import { ChangeStrategy } from './strategies/types';
-import { createBlockChangeLogStrategy } from './strategies/blockChangeLogStrategy';
-import { AppContext } from '../context/types';
 import { createClient } from '../client/createClient';
+import { AppContext } from '../context/types';
+import { createBlockChangeLogStrategy } from './strategies/blockChangeLogStrategy';
+import { createRevertReorgsStrategy } from './strategies/reorgCleanupStrategy';
+import { ChangeStrategy } from './strategies/types';
 
 
 const createBlockHandlerWithStrategies = async (
@@ -13,6 +14,7 @@ const createBlockHandlerWithStrategies = async (
   client: PublicClient
 ) => {
   const strategies: ChangeStrategy[] = [
+    createRevertReorgsStrategy(),
     createBlockChangeLogStrategy(),
   ];
 
@@ -60,4 +62,5 @@ const watchBlocks = async (
   });
 }
 
-export { watchBlocks }
+export { watchBlocks };
+

--- a/src/watchers/strategies/reorgCleanupStrategy.ts
+++ b/src/watchers/strategies/reorgCleanupStrategy.ts
@@ -1,0 +1,116 @@
+import { info } from 'loglevel';
+import { Hex, PublicClient } from 'viem';
+import { DatabaseContext } from '../../context/db';
+import { AppContext } from '../../context/types';
+import { BlockChangeLog, ChangeStrategy } from './types';
+import { getLastProcessedBlock } from './utils';
+
+const getBlockFromNode = (client: PublicClient, blockNumber: bigint) => {
+  return client.getBlock({ blockNumber });
+}
+
+const areHashesEqual = (a: Hex, b: Hex): boolean => {
+  return a === b;
+}
+
+const convertDbIdToHash = (id: string): Hex => {
+  return Buffer.from(id, 'hex').toString('utf-8') as Hex;
+}
+
+const fetchBatchByBlockNumberDesc = async (
+  db: DatabaseContext['db'],
+  fromBlockExclusive?: bigint,
+  limit = 1000
+): Promise<BlockChangeLog[]> => {
+  let query = db<BlockChangeLog>('BlockChangeLog')
+    .orderBy('blockNumber', 'desc')
+    .limit(limit);
+
+  if (fromBlockExclusive !== undefined) {
+    query = query.where('blockNumber', '<', fromBlockExclusive);
+  }
+
+  return query;
+}
+
+const BATCH_SIZE = 1000; // TODO: @jurajpiar make env var
+
+const findLastValidBlock = async (db: DatabaseContext['db'], client: PublicClient, fromBlock: bigint) => {
+
+  let upperExclusive: bigint = fromBlock
+
+  while (true) {
+    const candidates = await fetchBatchByBlockNumberDesc(db, upperExclusive, BATCH_SIZE);
+
+    if (candidates.length === 0) {
+      return -1n;
+    }
+
+    for (const block of candidates) {
+      const onchainBlock = await getBlockFromNode(client, block.blockNumber);
+
+      if (onchainBlock && areHashesEqual(convertDbIdToHash(block.id), onchainBlock.hash)) {
+        return block.blockNumber;
+      }
+    }
+
+    const last = candidates[candidates.length - 1];
+    upperExclusive = last.blockNumber;
+  }
+}
+
+export const createRevertReorgsStrategy = (): ChangeStrategy => {
+
+  const detectAndProcess = async ({
+    client,
+    context: {
+      dbContext: {
+        db
+      }
+    }
+  }: {
+    context: AppContext;
+    client: PublicClient;
+  }): Promise<boolean> => {
+    const { id, blockNumber } = await getLastProcessedBlock(db);
+
+    const {
+      hash: onchainBlockHash,
+    } = await client.getBlock({
+      blockNumber
+    })
+
+    const blockHash = convertDbIdToHash(id);
+
+    if (onchainBlockHash !== blockHash) {
+      info('Reorg detected');
+      const lastValidBlockNumber = await findLastValidBlock(db, client, blockNumber).catch((e) => {
+        throw new Error('Failed to find last valid block number with error: ' + e.message);
+
+      });
+
+      await db.transaction((tx) => {
+        // FIXME: None of the other tables reference block hash, which may cause data inconsistency when deleting block change logs
+        db<BlockChangeLog>('BlockChangeLog')
+          .transacting(tx)
+          .where('blockNumber', '>', lastValidBlockNumber).delete()
+          .then(tx.commit)
+          .catch((e) => {
+            tx.rollback();
+            throw new Error('Failed to delete block change logs with error: ' + e.message);
+          });
+      }).catch((e) => {
+        throw new Error('Reorg cleanup transaction failed with error: ' + e.message);
+      });
+
+      return true;
+    }
+
+    return false;
+  }
+
+  return {
+    name: 'reorgCleanupStrategy',
+    detectAndProcess
+  }
+}

--- a/src/watchers/strategies/types.ts
+++ b/src/watchers/strategies/types.ts
@@ -12,11 +12,14 @@ interface ChangeStrategy {
   detectAndProcess: (params: ChangeStrategyParams) => Promise<boolean>;
 }
 
+export type BlockHash = string
+
 interface BlockChangeLog {
-  id: string;
+  id: BlockHash;
   blockNumber: bigint;
   blockTimestamp: bigint;
   updatedEntities: string[];
 }
 
-export type { ChangeStrategyParams, ChangeStrategy, BlockChangeLog }
+export type { BlockChangeLog, ChangeStrategy, ChangeStrategyParams };
+

--- a/src/watchers/strategies/utils.ts
+++ b/src/watchers/strategies/utils.ts
@@ -1,0 +1,15 @@
+import { DatabaseContext } from "../../context/db";
+import { BlockChangeLog } from "./types";
+
+export const getLastProcessedBlock = async (
+    db: DatabaseContext['db']
+): Promise<BlockChangeLog> => {
+    const result = await db<BlockChangeLog>('BlockChangeLog').orderBy('blockNumber', 'desc').first()
+
+    return result ?? {
+        id: '0x00',
+        blockNumber: BigInt(0),
+        blockTimestamp: BigInt(0),
+        updatedEntities: []
+    }
+}


### PR DESCRIPTION
We can change this, but for now, I decided to create a new strategy for the reorgs.
It just invalidates (deletes) all the data from the last valid block (based on hash).
Then the strategies that follow process the missing blocks as per normal.

> [!IMPORTANT]
> Whether we delete the block change log data or not, we will need to create a task to link all the other data to the these, so that when the block change log gets updated, so will the rest of the data. @franciscotobar is going to create a task for this
