### PR TITLE
TOK-922: store last checked chain block

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -11,6 +11,19 @@ subgraphProvider:
   url: "https://gateway.thegraph.com/api"
   maxRowsPerRequest: 1000
 entities:
+  - name: LastProcessedBlock
+    columns:
+      - name: id
+        type: Boolean
+      - name: number
+        type: BigInt
+      - name: timestamp
+        type: BigInt
+      - name: hash
+        type: Bytes
+    primaryKey:
+      - id
+  
   - name: BlockChangeLog
     columns:
       - name: id

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -20,7 +20,7 @@ const main = async () => {
     const entities = await createDb(context, config.app);
 
     // Initial sync of entities
-    await syncEntities(context, entities);
+    await syncEntities(context, entities.filter(entity => entity !== 'LastProcessedBlock')); // TODO: We should change this a little bit, so that we don't have to filter out LastProcessedBlock here in this hardcoded way
 
     if (!productionMode) {
       process.exit(0);

--- a/src/handlers/subgraphSyncer.ts
+++ b/src/handlers/subgraphSyncer.ts
@@ -1,9 +1,9 @@
 import log from 'loglevel';
 
 import { executeRequests } from '../context/subgraphProvider';
-import { createEntityQueries } from './subgraphQueryBuilder';
-import { executeUpsert } from './dbUpsert';
 import { AppContext } from '../context/types';
+import { executeUpsert } from './dbUpsert';
+import { createEntityQueries } from './subgraphQueryBuilder';
 import { EntityDataCollection } from './types';
 
 interface EntitySyncStatus {
@@ -133,4 +133,5 @@ const syncEntities = async (
     await processEntityData(context, entityData);
 }
 
-export { syncEntities }
+export { syncEntities };
+

--- a/src/handlers/types.ts
+++ b/src/handlers/types.ts
@@ -1,4 +1,5 @@
 import { Knex } from 'knex';
+import { GraphQLMetadata } from '../context/subgraphProvider';
 
 type ColumnType = 'Boolean' | 'BigInt' | 'Bytes' | 'String' | 'Integer';
 type ArrayColumnType = [ColumnType];
@@ -41,10 +42,12 @@ const isArrayColumnType = (type: string | string[]): type is ArrayColumnType => 
         isColumnType(type[0]);
 }
 
-
-
 type EntityRecord = unknown & { id: string };
-type EntityDataCollection = Record<string, EntityRecord[]>;
 
-export type { ColumnType, ArrayColumnType, EntityDataCollection, EntityRecord, ColumnTypeConfig }
-export { columnTypeConfigs, isColumnType, isArrayColumnType }
+type WithMetadata = true;
+type EntityDataCollection<WMeta extends boolean = false> = WMeta extends WithMetadata ?
+    Record<string, EntityRecord[]> & { _meta: GraphQLMetadata } : Record<string, EntityRecord[]>;
+
+export { columnTypeConfigs, isArrayColumnType, isColumnType };
+export type { ArrayColumnType, ColumnType, ColumnTypeConfig, EntityDataCollection, EntityRecord, WithMetadata };
+

--- a/src/watchers/blockWatcher.ts
+++ b/src/watchers/blockWatcher.ts
@@ -4,7 +4,7 @@ import { PublicClient, type Block } from 'viem';
 
 import { createClient } from '../client/createClient';
 import { AppContext } from '../context/types';
-import { createBlockChangeLogStrategy } from './strategies/blockChangeLogStrategy';
+import blockChangeLogStrategy from './strategies/blockChangeLogStrategy';
 import { createRevertReorgsStrategy } from './strategies/reorgCleanupStrategy';
 import { ChangeStrategy } from './strategies/types';
 
@@ -15,7 +15,7 @@ const createBlockHandlerWithStrategies = async (
 ) => {
   const strategies: ChangeStrategy[] = [
     createRevertReorgsStrategy(),
-    createBlockChangeLogStrategy(),
+    blockChangeLogStrategy,
   ];
 
   return async (): Promise<void> => {

--- a/src/watchers/strategies/types.ts
+++ b/src/watchers/strategies/types.ts
@@ -21,5 +21,12 @@ interface BlockChangeLog {
   updatedEntities: string[];
 }
 
-export type { BlockChangeLog, ChangeStrategy, ChangeStrategyParams };
+interface LastProcessedBlock {
+  id: Boolean; // there will only ever be one last processed block
+  hash: BlockHash;
+  number: bigint;
+  timestamp: bigint;
+}
+
+export type { BlockChangeLog, ChangeStrategy, ChangeStrategyParams, LastProcessedBlock };
 


### PR DESCRIPTION
# WHAT

- adds a table to store last processed block
- modifies blockChangeLog strategy to update this on every block check

# WHY

- so that dApp does not have to call the graph and instead check the last block number

# TODO

- [x] run and test
