### PR TITLE
fix: reorg stategy remove LastProcessedBlock from sync

### DIFF
--- a/src/watchers/strategies/reorgCleanupStrategy.ts
+++ b/src/watchers/strategies/reorgCleanupStrategy.ts
@@ -45,7 +45,7 @@ export const createRevertReorgsStrategy = (): ChangeStrategy => {
       const entities = await createDb(newContext, IS_PRODUCTION_MODE, SHOULD_INITIALIZE_DB);
 
       // Initial sync of entities
-      await syncEntities(newContext, entities);
+      await syncEntities(newContext, entities.filter(entity => entity !== 'LastProcessedBlock'));
 
       await switchSchema(dbContext, NEW_SCHEMA, PUBLIC_SCHEMA);
 


### PR DESCRIPTION
While doing reorg we were syncing `LastProcessedBlock` which is a auxiliary table that is not in any subgraph