### PR TITLE
feat: add block interval throttling for proposal sync strategy

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -339,12 +339,3 @@ entities:
     primaryKey:
       - id
     subgraphProvider: "governance"
-  - name: Variables
-    columns:
-      - name: key
-        type: String
-      - name: value
-        type: String
-    primaryKey:
-      - key
-    subgraphProvider: "collective-rewards"

--- a/config/default.yml
+++ b/config/default.yml
@@ -7,6 +7,8 @@ database:
   maxRetries: 3
   initialRetryDelay: 1000
   ssl: true
+blockchain:
+  blockIntervalThreshold: 3
 subgraphProviders:
   collective-rewards:
     url: "https://gateway.thegraph.com/api"

--- a/config/default.yml
+++ b/config/default.yml
@@ -339,3 +339,12 @@ entities:
     primaryKey:
       - id
     subgraphProvider: "governance"
+  - name: Variables
+    columns:
+      - name: key
+        type: String
+      - name: value
+        type: String
+    primaryKey:
+      - key
+    subgraphProvider: "collective-rewards"

--- a/config/mainnet.yml
+++ b/config/mainnet.yml
@@ -3,6 +3,7 @@ app:
   initializeDb: true
 blockchain:
   network: "mainnet"
+  blockIntervalThreshold: 1
 subgraphProviders:
   collective-rewards:
     id: "deployments/id/QmUkydakVyQexGfbUubdz58M7Bw2uiAAd1KvUNiEBj4jJh"

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -28,6 +28,7 @@ interface Database {
 
 interface Blockchain {
     network: SupportedChain;
+    blockIntervalThreshold: number;
 }
 
 interface SubgraphProvider {

--- a/src/watchers/strategies/blockProposalStrategy.ts
+++ b/src/watchers/strategies/blockProposalStrategy.ts
@@ -25,7 +25,7 @@ const createStrategy = (): ChangeStrategy => {
     }
 
     const BLOCK_INTERVAL_THRESHOLD = BigInt(getConfig().blockchain.blockIntervalThreshold);
-    console.log(28, { BLOCK_INTERVAL_THRESHOLD })
+
     // Check if current block is at least BLOCK_INTERVAL blocks after last processed block
     if (LAST_PROCESSED_BLOCK > 0n && params.blockNumber < (LAST_PROCESSED_BLOCK + BLOCK_INTERVAL_THRESHOLD)) {
       const blocksUntilNext = (LAST_PROCESSED_BLOCK + BLOCK_INTERVAL_THRESHOLD) - params.blockNumber;

--- a/src/watchers/strategies/blockProposalStrategy.ts
+++ b/src/watchers/strategies/blockProposalStrategy.ts
@@ -5,9 +5,9 @@ import log from 'loglevel';
 import { createEntityQuery } from '../../handlers/subgraphQueryBuilder';
 import { executeRequests } from '../../context/subgraphProvider';
 import { syncEntities } from '../../handlers/subgraphSyncer';
+import { getConfig } from '../../config/config';
 
 const MAINNET_VOTING_PERIOD_BLOCKS = 25000n
-const BLOCK_INTERVAL_THRESHOLD = 3n; // Minimum blocks that must pass
 
 let LAST_PROCESSED_BLOCK = 0n;
 
@@ -24,6 +24,8 @@ const createStrategy = (): ChangeStrategy => {
       return false;
     }
 
+    const BLOCK_INTERVAL_THRESHOLD = BigInt(getConfig().blockchain.blockIntervalThreshold);
+    console.log(28, { BLOCK_INTERVAL_THRESHOLD })
     // Check if current block is at least BLOCK_INTERVAL blocks after last processed block
     if (LAST_PROCESSED_BLOCK > 0n && params.blockNumber < (LAST_PROCESSED_BLOCK + BLOCK_INTERVAL_THRESHOLD)) {
       const blocksUntilNext = (LAST_PROCESSED_BLOCK + BLOCK_INTERVAL_THRESHOLD) - params.blockNumber;


### PR DESCRIPTION
  Added Variables table to store last processed block number and implemented
  block interval checking in the proposal strategy. The strategy now only
  processes proposals every 3 blocks to reduce graph queries.

  Changes:
  - Added Variables entity to default.yml with key-value schema
  - Implemented block interval threshold (2n) in blockProposalStrategy
  - Store and retrieve last processed block from Variables table
  - Skip processing if fewer than 3 blocks have passed since last run