### PR TITLE
DAO-1648 [State Sync] Sync proposals that their current state can change

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -9,6 +9,8 @@ database:
   ssl: true
 blockchain:
   blockIntervalThreshold: 3
+  oldProposalCheckIntervalBlocks: 15  # ~7.5 minutes at 30s/block
+  blocksPerWeek: 20160  # 7 days * 24h * 3600s / 30s per block
 subgraphProviders:
   collective-rewards:
     url: "https://gateway.thegraph.com/api"

--- a/config/local.yml
+++ b/config/local.yml
@@ -1,0 +1,3 @@
+database:
+  connectionString: "postgresql://test:test@localhost:5432/test"
+

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -29,6 +29,8 @@ interface Database {
 interface Blockchain {
     network: SupportedChain;
     blockIntervalThreshold: number;
+    oldProposalCheckIntervalBlocks?: number;
+    blocksPerWeek?: number;
 }
 
 interface SubgraphProvider {

--- a/src/test-helpers/testContext.ts
+++ b/src/test-helpers/testContext.ts
@@ -1,0 +1,112 @@
+import { Config } from '../config/types';
+import { createContexts } from '../context/create';
+import { createMockConfig } from './mockConfig';
+import { DatabaseContext } from '../context/db';
+import { AppContext } from '../context/types';
+import { createDb } from '../handlers/dbCreator';
+
+/**
+ * Creates a real test AppContext with an actual database connection.
+ * 
+ * Uses TEST_DATABASE_URL or default test database connection.
+ * Requires test database to be running (e.g., via docker-compose up -d postgres).
+ * 
+ * Usage:
+ * ```typescript
+ * describe('Integration tests', () => {
+ *   let testContext: AppContext;
+ *   
+ *   before(async () => {
+ *     testContext = await createTestContext();
+ *   });
+ *   
+ *   after(async () => {
+ *     await teardownTestContext(testContext);
+ *   });
+ *   
+ *   beforeEach(async () => {
+ *     await cleanTestDatabase(testContext.dbContext);
+ *   });
+ * });
+ * ```
+ */
+export const createTestContext = async (
+  overrides?: Partial<Config>
+): Promise<AppContext> => {
+  const config = createMockConfig({
+    ...overrides,
+    database: {
+      connectionString: process.env.TEST_DATABASE_URL || 
+        'postgresql://test:test@localhost:5432/test',
+      batchSize: 100,
+      maxRetries: 1,
+      initialRetryDelay: 100,
+      ssl: false,
+      ...overrides?.database
+    },
+    app: {
+      initializeDb: true,
+      logLevel: 'error',
+      productionMode: false,
+      ...overrides?.app
+    }
+  });
+
+  const context = createContexts(config);
+  
+  // Initialize database schema (create tables)
+  await createDb(context, false, true);
+  
+  return context;
+};
+
+/**
+ * Tears down the test context.
+ */
+export const teardownTestContext = async (context: AppContext): Promise<void> => {
+  await context.dbContext.db.destroy();
+};
+
+/**
+ * Creates a test database context with a real connection.
+ * Useful for testing database queries in isolation.
+ */
+export const createTestDatabaseContext = async (
+  connectionString?: string
+): Promise<DatabaseContext> => {
+  const { createDatabaseContext, PUBLIC_SCHEMA } = await import('../context/db.js');
+  
+  return createDatabaseContext(
+    {
+      connectionString: connectionString || 
+        process.env.TEST_DATABASE_URL || 
+        'postgresql://test:test@localhost:5432/test',
+      batchSize: 100,
+      maxRetries: 1,
+      initialRetryDelay: 100,
+      ssl: false
+    },
+    PUBLIC_SCHEMA
+  );
+};
+
+/**
+ * Helper to clean all tables in the test database.
+ * Use in beforeEach/afterEach to ensure test isolation.
+ */
+export const cleanTestDatabase = async (dbContext: DatabaseContext): Promise<void> => {
+  const { db } = dbContext;
+  
+  // Get all table names
+  const tables = await db.raw(`
+    SELECT tablename 
+    FROM pg_tables 
+    WHERE schemaname = 'public'
+  `);
+  
+  // Truncate all tables (faster than delete, resets sequences)
+  for (const row of tables.rows) {
+    await db.raw(`TRUNCATE TABLE "${row.tablename}" RESTART IDENTITY CASCADE`);
+  }
+};
+

--- a/src/watchers/blockWatcher.ts
+++ b/src/watchers/blockWatcher.ts
@@ -7,7 +7,7 @@ import { AppContext } from '../context/types';
 import blockChangeLogStrategy from './strategies/blockChangeLogStrategy';
 import { createRevertReorgsStrategy } from './strategies/reorgCleanupStrategy';
 import { ChangeStrategy } from './strategies/types';
-import { createNewProposalStrategy, createProposalStateStrategy } from './strategies';
+import { createNewProposalStrategy, createProposalStateStrategy, createOldProposalStateStrategy } from './strategies';
 
 
 const createBlockHandlerWithStrategies = async (
@@ -19,6 +19,7 @@ const createBlockHandlerWithStrategies = async (
     blockChangeLogStrategy,
     createNewProposalStrategy(),
     createProposalStateStrategy(),
+    createOldProposalStateStrategy(),
   ];
 
   return async (blockNumber: bigint | null): Promise<void> => {

--- a/src/watchers/strategies/index.ts
+++ b/src/watchers/strategies/index.ts
@@ -1,2 +1,3 @@
 export { createProposalStateStrategy } from './blockProposalStateStrategy';
+export { createOldProposalStateStrategy } from './oldProposalStateStrategy';
 export { createNewProposalStrategy } from './blockProposalStrategy';

--- a/src/watchers/strategies/oldProposalStateStrategy.test.ts
+++ b/src/watchers/strategies/oldProposalStateStrategy.test.ts
@@ -1,0 +1,817 @@
+/**
+ * Integration tests for oldProposalStateStrategy using a real test database.
+ * 
+ * These tests verify:
+ * - Real database queries work correctly
+ * - Interval-based checking logic
+ * - Old proposal filtering (older than one week)
+ * - Configuration usage
+ * - Error handling with real errors
+ * 
+ * Requires test database to be running (e.g., via docker-compose up -d postgres).
+ * Set TEST_DATABASE_URL environment variable or use default: postgresql://test:test@localhost:5432/test
+ * 
+ * Note: These tests use a real database but mock the blockchain client.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it, before, after, beforeEach, mock } from 'node:test';
+import { createOldProposalStateStrategy } from './oldProposalStateStrategy';
+import { createTestContext, cleanTestDatabase, teardownTestContext } from '../../test-helpers/testContext';
+import { AppContext } from '../../context/types';
+import { ProposalState } from './shared/proposalStateHelpers';
+import { Proposal } from './types';
+import { PublicClient } from 'viem';
+
+describe('oldProposalStateStrategy', () => {
+  let testContext: AppContext;
+  let strategy: ReturnType<typeof createOldProposalStateStrategy>;
+  let mockClient: any;
+
+  before(async () => {
+    // Automatically creates and starts test database container
+    testContext = await createTestContext({
+      contracts: [{ name: 'Governor', address: '0x1234567890123456789012345678901234567890' }],
+      blockchain: {
+        network: 'testnet',
+        blockIntervalThreshold: 1,
+        oldProposalCheckIntervalBlocks: 10,
+        blocksPerWeek: 20160
+      }
+    });
+
+    // Mock PublicClient for blockchain calls
+    mockClient = {
+      multicall: mock.fn()
+    };
+  });
+
+  after(async () => {
+    // Automatically stops and removes test database container
+    await teardownTestContext(testContext);
+  });
+
+  beforeEach(async () => {
+    // Clean all tables before each test
+    await cleanTestDatabase(testContext.dbContext);
+    // Reset mock calls (implementation will be set per test)
+    mockClient.multicall.mock.resetCalls();
+    // Create a fresh strategy instance for each test to reset internal state
+    strategy = createOldProposalStateStrategy();
+  });
+
+  describe('Strategy creation', () => {
+    it('should create strategy with correct name', () => {
+      assert.equal(strategy.name, 'OldProposalState');
+    });
+
+    it('should have detectAndProcess function', () => {
+      assert.equal(typeof strategy.detectAndProcess, 'function');
+    });
+  });
+
+  describe('Interval-based checking', () => {
+    it('should check old proposals on first call', async () => {
+      const { db } = testContext.dbContext;
+
+      // Insert old proposal (created more than one week ago)
+      const currentBlock = BigInt(25000);
+      const oneWeekAgoBlock = currentBlock - BigInt(20160);
+      
+      // Create Account first (required for proposer relation)
+      await db('Account').insert({
+        id: '0x0000000000000000000000000000000000000001'
+      });
+
+      await db<Proposal>('Proposal').insert({
+        id: 'prop1',
+        proposalId: '1',
+        rawState: ProposalState.Succeeded,
+        state: 'Succeeded',
+        createdAtBlock: oneWeekAgoBlock - BigInt(100), // Older than one week
+        voteStart: BigInt(0),
+        voteEnd: BigInt(0),
+        votesFor: BigInt(0),
+        votesAgainst: BigInt(0),
+        votesAbstains: BigInt(0),
+        quorum: BigInt(0),
+        description: 'Old proposal',
+        createdAt: BigInt(0),
+        signatures: [],
+        targets: [],
+        values: [],
+        calldatas: [],
+        proposer: '0x0000000000000000000000000000000000000001'
+      } as any);
+
+      // Mock multicall to return different state
+      mockClient.multicall.mock.mockImplementation(() => Promise.resolve([
+        { status: 'success', result: ProposalState.Queued }
+      ]));
+
+      const result = await strategy.detectAndProcess({
+        context: testContext,
+        client: mockClient as PublicClient,
+        blockNumber: currentBlock
+      });
+
+      // Should check old proposals on first call
+      assert.equal(mockClient.multicall.mock.callCount(), 1);
+      assert.ok(result);
+    });
+
+    it('should skip check if interval not met', async () => {
+      // First call - sets LAST_OLD_PROPOSALS_CHECK_BLOCK
+      await strategy.detectAndProcess({
+        context: testContext,
+        client: mockClient as PublicClient,
+        blockNumber: BigInt(10000)
+      });
+
+      // Reset mock call count
+      mockClient.multicall.mock.resetCalls();
+
+      // Second call - only 5 blocks later (interval is 10)
+      const result = await strategy.detectAndProcess({
+        context: testContext,
+        client: mockClient as PublicClient,
+        blockNumber: BigInt(10005)
+      });
+
+      // Should skip - no multicall
+      assert.equal(mockClient.multicall.mock.callCount(), 0);
+      assert.equal(result, false);
+    });
+
+    it('should check when interval threshold is met', async () => {
+      const { db } = testContext.dbContext;
+
+      // First call
+      await strategy.detectAndProcess({
+        context: testContext,
+        client: mockClient as PublicClient,
+        blockNumber: BigInt(10000)
+      });
+
+      // Insert old proposal
+      const currentBlock = BigInt(10010);
+      const oneWeekAgoBlock = currentBlock - BigInt(20160);
+      
+      // Create Account first
+      await db('Account').insert({
+        id: '0x0000000000000000000000000000000000000001'
+      });
+
+      await db<Proposal>('Proposal').insert({
+        id: 'prop1',
+        proposalId: '1',
+        rawState: ProposalState.Succeeded,
+        state: 'Succeeded',
+        createdAtBlock: oneWeekAgoBlock - BigInt(100),
+        voteStart: BigInt(0),
+        voteEnd: BigInt(0),
+        votesFor: BigInt(0),
+        votesAgainst: BigInt(0),
+        votesAbstains: BigInt(0),
+        quorum: BigInt(0),
+        description: 'Old proposal',
+        createdAt: BigInt(0),
+        signatures: [],
+        targets: [],
+        values: [],
+        calldatas: [],
+        proposer: '0x0000000000000000000000000000000000000001'
+      } as any);
+
+      // Reset mock
+      mockClient.multicall.mock.resetCalls();
+      mockClient.multicall.mock.mockImplementation(() => Promise.resolve([
+        { status: 'success', result: ProposalState.Queued }
+      ]));
+
+      // Second call - exactly 10 blocks later (meets interval)
+      const result = await strategy.detectAndProcess({
+        context: testContext,
+        client: mockClient as PublicClient,
+        blockNumber: currentBlock
+      });
+
+      // Should check old proposals
+      assert.equal(mockClient.multicall.mock.callCount(), 1);
+      assert.ok(result);
+    });
+  });
+
+  describe('Old proposal filtering', () => {
+    it('should only query proposals older than one week', async () => {
+      const { db } = testContext.dbContext;
+
+      const currentBlock = BigInt(25000);
+      const oneWeekAgoBlock = currentBlock - BigInt(20160);
+
+      // Create Accounts first
+      await db('Account').insert([
+        { id: '0x0000000000000000000000000000000000000001' },
+        { id: '0x0000000000000000000000000000000000000002' }
+      ]);
+
+      // Insert old proposal (older than one week)
+      await db<Proposal>('Proposal').insert({
+        id: 'old-prop',
+        proposalId: '1',
+        rawState: ProposalState.Succeeded,
+        state: 'Succeeded',
+        createdAtBlock: oneWeekAgoBlock - BigInt(100), // Older
+        voteStart: BigInt(0),
+        voteEnd: BigInt(0),
+        votesFor: BigInt(0),
+        votesAgainst: BigInt(0),
+        votesAbstains: BigInt(0),
+        quorum: BigInt(0),
+        description: 'Old proposal',
+        createdAt: BigInt(0),
+        signatures: [],
+        targets: [],
+        values: [],
+        calldatas: [],
+        proposer: '0x0000000000000000000000000000000000000001'
+      } as any);
+
+      // Insert recent proposal (less than one week old)
+      await db<Proposal>('Proposal').insert({
+        id: 'recent-prop',
+        proposalId: '2',
+        rawState: ProposalState.Succeeded,
+        state: 'Succeeded',
+        createdAtBlock: currentBlock - BigInt(1000), // Recent
+        voteStart: BigInt(0),
+        voteEnd: BigInt(0),
+        votesFor: BigInt(0),
+        votesAgainst: BigInt(0),
+        votesAbstains: BigInt(0),
+        quorum: BigInt(0),
+        description: 'Recent proposal',
+        createdAt: BigInt(0),
+        signatures: [],
+        targets: [],
+        values: [],
+        calldatas: [],
+        proposer: '0x0000000000000000000000000000000000000002'
+      } as any);
+
+      mockClient.multicall.mock.mockImplementation(() => Promise.resolve([
+        { status: 'success', result: ProposalState.Queued }
+      ]));
+
+      await strategy.detectAndProcess({
+        context: testContext,
+        client: mockClient as PublicClient,
+        blockNumber: currentBlock
+      });
+
+      // Should only query old proposal (multicall called once, not twice)
+      assert.equal(mockClient.multicall.mock.callCount(), 1);
+      
+      // Verify only old proposal was updated
+      const oldProp = await db<Proposal>('Proposal').where('id', 'old-prop').first();
+      const recentProp = await db<Proposal>('Proposal').where('id', 'recent-prop').first();
+      
+      assert.equal(oldProp?.rawState, ProposalState.Queued); // Updated
+      assert.equal(recentProp?.rawState, ProposalState.Succeeded); // Not updated
+    });
+
+    it('should process multiple old proposals', async () => {
+      const { db } = testContext.dbContext;
+
+      const currentBlock = BigInt(25000);
+      const oneWeekAgoBlock = currentBlock - BigInt(20160);
+
+      // Create Accounts first
+      await db('Account').insert([
+        { id: '0x0000000000000000000000000000000000000001' },
+        { id: '0x0000000000000000000000000000000000000002' },
+        { id: '0x0000000000000000000000000000000000000003' }
+      ]);
+
+      // Insert multiple old proposals
+      await db<Proposal>('Proposal').insert([
+        {
+          id: 'old-prop-1',
+          proposalId: '1',
+          rawState: ProposalState.Succeeded,
+          state: 'Succeeded',
+          createdAtBlock: oneWeekAgoBlock - BigInt(200),
+          voteStart: BigInt(0),
+          voteEnd: BigInt(0),
+          votesFor: BigInt(0),
+          votesAgainst: BigInt(0),
+          votesAbstains: BigInt(0),
+          quorum: BigInt(0),
+          description: 'Old proposal 1',
+          createdAt: BigInt(0),
+          signatures: [],
+          targets: [],
+          values: [],
+          calldatas: [],
+          proposer: '0x0000000000000000000000000000000000000001'
+        },
+        {
+          id: 'old-prop-2',
+          proposalId: '2',
+          rawState: ProposalState.Queued,
+          state: 'Queued',
+          createdAtBlock: oneWeekAgoBlock - BigInt(500),
+          voteStart: BigInt(0),
+          voteEnd: BigInt(0),
+          votesFor: BigInt(0),
+          votesAgainst: BigInt(0),
+          votesAbstains: BigInt(0),
+          quorum: BigInt(0),
+          description: 'Old proposal 2',
+          createdAt: BigInt(0),
+          signatures: [],
+          targets: [],
+          values: [],
+          calldatas: [],
+          proposer: '0x0000000000000000000000000000000000000002'
+        },
+        {
+          id: 'old-prop-3',
+          proposalId: '3',
+          rawState: ProposalState.Succeeded,
+          state: 'Succeeded',
+          createdAtBlock: oneWeekAgoBlock - BigInt(1000),
+          voteStart: BigInt(0),
+          voteEnd: BigInt(0),
+          votesFor: BigInt(0),
+          votesAgainst: BigInt(0),
+          votesAbstains: BigInt(0),
+          quorum: BigInt(0),
+          description: 'Old proposal 3',
+          createdAt: BigInt(0),
+          signatures: [],
+          targets: [],
+          values: [],
+          calldatas: [],
+          proposer: '0x0000000000000000000000000000000000000003'
+        }
+      ] as any[]);
+
+      // Mock multicall to return different states for each proposal
+      mockClient.multicall.mock.mockImplementation(() => Promise.resolve([
+        { status: 'success', result: ProposalState.Executed }, // prop 1: Succeeded -> Executed
+        { status: 'success', result: ProposalState.Executed }, // prop 2: Queued -> Executed
+        { status: 'success', result: ProposalState.Expired }   // prop 3: Succeeded -> Expired
+      ]));
+
+      const result = await strategy.detectAndProcess({
+        context: testContext,
+        client: mockClient as PublicClient,
+        blockNumber: currentBlock
+      });
+
+      // Should call multicall once with all 3 proposals
+      assert.equal(mockClient.multicall.mock.callCount(), 1);
+      assert.ok(result);
+
+      // Verify all proposals were updated
+      const prop1 = await db<Proposal>('Proposal').where('id', 'old-prop-1').first();
+      const prop2 = await db<Proposal>('Proposal').where('id', 'old-prop-2').first();
+      const prop3 = await db<Proposal>('Proposal').where('id', 'old-prop-3').first();
+
+      assert.equal(prop1?.rawState, ProposalState.Executed);
+      assert.equal(prop1?.state, 'Executed');
+      assert.equal(prop2?.rawState, ProposalState.Executed);
+      assert.equal(prop2?.state, 'Executed');
+      assert.equal(prop3?.rawState, ProposalState.Expired);
+      assert.equal(prop3?.state, 'Expired');
+    });
+
+    it('should exclude proposals exactly at one-week boundary', async () => {
+      const { db } = testContext.dbContext;
+
+      const currentBlock = BigInt(25000);
+      const oneWeekAgoBlock = currentBlock - BigInt(20160);
+
+      // Create Accounts first
+      await db('Account').insert([
+        { id: '0x0000000000000000000000000000000000000001' },
+        { id: '0x0000000000000000000000000000000000000002' }
+      ]);
+
+      // Insert proposal exactly at one-week boundary (should be excluded - query uses < not <=)
+      await db<Proposal>('Proposal').insert({
+        id: 'boundary-prop',
+        proposalId: '1',
+        rawState: ProposalState.Succeeded,
+        state: 'Succeeded',
+        createdAtBlock: oneWeekAgoBlock, // Exactly one week ago
+        voteStart: BigInt(0),
+        voteEnd: BigInt(0),
+        votesFor: BigInt(0),
+        votesAgainst: BigInt(0),
+        votesAbstains: BigInt(0),
+        quorum: BigInt(0),
+        description: 'Boundary proposal',
+        createdAt: BigInt(0),
+        signatures: [],
+        targets: [],
+        values: [],
+        calldatas: [],
+        proposer: '0x0000000000000000000000000000000000000001'
+      } as any);
+
+      // Insert proposal just before boundary (should be included)
+      await db<Proposal>('Proposal').insert({
+        id: 'just-old-prop',
+        proposalId: '2',
+        rawState: ProposalState.Succeeded,
+        state: 'Succeeded',
+        createdAtBlock: oneWeekAgoBlock - BigInt(1), // Just before boundary
+        voteStart: BigInt(0),
+        voteEnd: BigInt(0),
+        votesFor: BigInt(0),
+        votesAgainst: BigInt(0),
+        votesAbstains: BigInt(0),
+        quorum: BigInt(0),
+        description: 'Just old proposal',
+        createdAt: BigInt(0),
+        signatures: [],
+        targets: [],
+        values: [],
+        calldatas: [],
+        proposer: '0x0000000000000000000000000000000000000002'
+      } as any);
+
+      mockClient.multicall.mock.mockImplementation(() => Promise.resolve([
+        { status: 'success', result: ProposalState.Queued }
+      ]));
+
+      await strategy.detectAndProcess({
+        context: testContext,
+        client: mockClient as PublicClient,
+        blockNumber: currentBlock
+      });
+
+      // Should only query the proposal just before boundary (multicall called once, not twice)
+      assert.equal(mockClient.multicall.mock.callCount(), 1);
+
+      // Verify only the just-old proposal was updated
+      const boundaryProp = await db<Proposal>('Proposal').where('id', 'boundary-prop').first();
+      const justOldProp = await db<Proposal>('Proposal').where('id', 'just-old-prop').first();
+
+      assert.equal(boundaryProp?.rawState, ProposalState.Succeeded); // Not updated
+      assert.equal(justOldProp?.rawState, ProposalState.Queued); // Updated
+    });
+
+    it('should call multicall with correct parameters matching viem structure', async () => {
+      const { db } = testContext.dbContext;
+
+      const currentBlock = BigInt(25000);
+      const oneWeekAgoBlock = currentBlock - BigInt(20160);
+
+      // Create Account first
+      await db('Account').insert({
+        id: '0x0000000000000000000000000000000000000001'
+      });
+
+      // Insert old proposals with different IDs
+      await db<Proposal>('Proposal').insert([
+        {
+          id: 'prop-1',
+          proposalId: '10',
+          rawState: ProposalState.Succeeded,
+          state: 'Succeeded',
+          createdAtBlock: oneWeekAgoBlock - BigInt(100),
+          voteStart: BigInt(0),
+          voteEnd: BigInt(0),
+          votesFor: BigInt(0),
+          votesAgainst: BigInt(0),
+          votesAbstains: BigInt(0),
+          quorum: BigInt(0),
+          description: 'Proposal 1',
+          createdAt: BigInt(0),
+          signatures: [],
+          targets: [],
+          values: [],
+          calldatas: [],
+          proposer: '0x0000000000000000000000000000000000000001'
+        },
+        {
+          id: 'prop-2',
+          proposalId: '20',
+          rawState: ProposalState.Queued,
+          state: 'Queued',
+          createdAtBlock: oneWeekAgoBlock - BigInt(200),
+          voteStart: BigInt(0),
+          voteEnd: BigInt(0),
+          votesFor: BigInt(0),
+          votesAgainst: BigInt(0),
+          votesAbstains: BigInt(0),
+          quorum: BigInt(0),
+          description: 'Proposal 2',
+          createdAt: BigInt(0),
+          signatures: [],
+          targets: [],
+          values: [],
+          calldatas: [],
+          proposer: '0x0000000000000000000000000000000000000001'
+        }
+      ] as any[]);
+
+      mockClient.multicall.mock.mockImplementation(() => Promise.resolve([
+        { status: 'success', result: ProposalState.Executed },
+        { status: 'success', result: ProposalState.Expired }
+      ]));
+
+      await strategy.detectAndProcess({
+        context: testContext,
+        client: mockClient as PublicClient,
+        blockNumber: currentBlock
+      });
+
+      // Verify multicall was called once
+      assert.equal(mockClient.multicall.mock.callCount(), 1);
+
+      // Verify multicall was called with correct structure matching viem's multicall API
+      const multicallCall = mockClient.multicall.mock.calls[0];
+      assert.ok(multicallCall);
+      assert.ok(multicallCall.arguments);
+      assert.equal(multicallCall.arguments.length, 1);
+      
+      const multicallParams = multicallCall.arguments[0];
+      assert.ok(multicallParams.contracts);
+      assert.equal(multicallParams.contracts.length, 2);
+      
+      // Verify each contract call has the correct structure
+      const call1 = multicallParams.contracts[0];
+      assert.equal(call1.address, '0x1234567890123456789012345678901234567890');
+      assert.equal(call1.functionName, 'state');
+      assert.deepEqual(call1.args, [BigInt(10)]);
+      
+      const call2 = multicallParams.contracts[1];
+      assert.equal(call2.address, '0x1234567890123456789012345678901234567890');
+      assert.equal(call2.functionName, 'state');
+      assert.deepEqual(call2.args, [BigInt(20)]);
+    });
+  });
+
+  describe('Configuration', () => {
+    it('should use configured interval blocks', async () => {
+      const customContext = await createTestContext({
+        contracts: [{ name: 'Governor', address: '0x1234567890123456789012345678901234567890' }],
+        blockchain: {
+          network: 'testnet',
+          blockIntervalThreshold: 1,
+          oldProposalCheckIntervalBlocks: 20, // Custom interval
+          blocksPerWeek: 20160
+        }
+      });
+
+      const customStrategy = createOldProposalStateStrategy();
+
+      // First call
+      await customStrategy.detectAndProcess({
+        context: customContext,
+        client: mockClient as PublicClient,
+        blockNumber: BigInt(10000)
+      });
+
+      mockClient.multicall.mock.resetCalls();
+
+      // Second call - 15 blocks later (should skip, interval is 20)
+      const result2 = await customStrategy.detectAndProcess({
+        context: customContext,
+        client: mockClient as PublicClient,
+        blockNumber: BigInt(10015)
+      });
+
+      // Should skip - no database queries
+      assert.equal(mockClient.multicall.mock.callCount(), 0);
+      assert.equal(result2, false);
+
+      // Third call - 20 blocks later (should check)
+      await customStrategy.detectAndProcess({
+        context: customContext,
+        client: mockClient as PublicClient,
+        blockNumber: BigInt(10020)
+      });
+
+      // Should check
+      assert.equal(mockClient.multicall.mock.callCount(), 0); // No proposals, but query was made
+
+      await teardownTestContext(customContext);
+    });
+
+    it('should use default values when config missing', async () => {
+      const contextWithDefaults = await createTestContext({
+        contracts: [{ name: 'Governor', address: '0x1234567890123456789012345678901234567890' }],
+        blockchain: {
+          network: 'testnet',
+          blockIntervalThreshold: 3
+          // Missing oldProposalCheckIntervalBlocks and blocksPerWeek (testing defaults)
+        }
+      });
+
+      // Should use defaults (15 blocks interval, 20160 blocks per week)
+      const result = await strategy.detectAndProcess({
+        context: contextWithDefaults,
+        client: mockClient as PublicClient,
+        blockNumber: BigInt(10000)
+      });
+
+      // Should work with defaults (no proposals, but query executed)
+      assert.equal(result, false);
+
+      await teardownTestContext(contextWithDefaults);
+    });
+
+    it('should use custom blocksPerWeek value', async () => {
+      const customContext = await createTestContext({
+        contracts: [{ name: 'Governor', address: '0x1234567890123456789012345678901234567890' }],
+        blockchain: {
+          network: 'testnet',
+          blockIntervalThreshold: 1,
+          oldProposalCheckIntervalBlocks: 10,
+          blocksPerWeek: 10000 // Custom: 10000 blocks per week instead of 20160
+        }
+      });
+
+      const { db } = customContext.dbContext;
+      const customStrategy = createOldProposalStateStrategy();
+
+      const currentBlock = BigInt(25000);
+      const oneWeekAgoBlock = currentBlock - BigInt(10000); // Using custom blocksPerWeek
+
+      // Create Account first
+      await db('Account').insert({
+        id: '0x0000000000000000000000000000000000000001'
+      });
+
+      // Insert proposal that is old according to custom blocksPerWeek
+      await db<Proposal>('Proposal').insert({
+        id: 'custom-old-prop',
+        proposalId: '1',
+        rawState: ProposalState.Succeeded,
+        state: 'Succeeded',
+        createdAtBlock: oneWeekAgoBlock - BigInt(100), // Older than custom one week
+        voteStart: BigInt(0),
+        voteEnd: BigInt(0),
+        votesFor: BigInt(0),
+        votesAgainst: BigInt(0),
+        votesAbstains: BigInt(0),
+        quorum: BigInt(0),
+        description: 'Custom old proposal',
+        createdAt: BigInt(0),
+        signatures: [],
+        targets: [],
+        values: [],
+        calldatas: [],
+        proposer: '0x0000000000000000000000000000000000000001'
+      } as any);
+
+      // Insert proposal that would be old with default blocksPerWeek but recent with custom
+      await db<Proposal>('Proposal').insert({
+        id: 'custom-recent-prop',
+        proposalId: '2',
+        rawState: ProposalState.Succeeded,
+        state: 'Succeeded',
+        createdAtBlock: oneWeekAgoBlock + BigInt(100), // Recent (just after the boundary) with custom blocksPerWeek
+        voteStart: BigInt(0),
+        voteEnd: BigInt(0),
+        votesFor: BigInt(0),
+        votesAgainst: BigInt(0),
+        votesAbstains: BigInt(0),
+        quorum: BigInt(0),
+        description: 'Custom recent proposal',
+        createdAt: BigInt(0),
+        signatures: [],
+        targets: [],
+        values: [],
+        calldatas: [],
+        proposer: '0x0000000000000000000000000000000000000001'
+      } as any);
+
+      // Mock multicall - only 1 old proposal should be queried, so return 1 result
+      // The mock should return results matching the number of proposals queried
+      mockClient.multicall.mock.mockImplementation((params: any) => {
+        const numContracts = params?.contracts?.length ?? 1;
+        return Promise.resolve(
+          Array.from({ length: numContracts }, () => ({
+            status: 'success' as const,
+            result: ProposalState.Queued
+          }))
+        );
+      });
+
+      const result = await customStrategy.detectAndProcess({
+        context: customContext,
+        client: mockClient as PublicClient,
+        blockNumber: currentBlock
+      });
+
+      // Should only query the custom-old proposal (multicall called once, not twice)
+      assert.equal(mockClient.multicall.mock.callCount(), 1);
+      assert.ok(result);
+
+      // Verify only custom-old proposal was updated
+      const customOldProp = await db<Proposal>('Proposal').where('id', 'custom-old-prop').first();
+      const customRecentProp = await db<Proposal>('Proposal').where('id', 'custom-recent-prop').first();
+
+      assert.equal(customOldProp?.rawState, ProposalState.Queued); // Updated
+      assert.equal(customRecentProp?.rawState, ProposalState.Succeeded); // Not updated (recent with custom blocksPerWeek)
+
+      await teardownTestContext(customContext);
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should return false when block number is null', async () => {
+      const result = await strategy.detectAndProcess({
+        context: testContext,
+        client: mockClient as PublicClient,
+        blockNumber: null
+      });
+
+      assert.equal(result, false);
+      assert.equal(mockClient.multicall.mock.callCount(), 0);
+    });
+
+    it('should return false when governance address not configured', async () => {
+      const contextWithoutGovernor = await createTestContext({
+        contracts: [] // No Governor contract
+      });
+
+      const result = await strategy.detectAndProcess({
+        context: contextWithoutGovernor,
+        client: mockClient as PublicClient,
+        blockNumber: BigInt(20000)
+      });
+
+      assert.equal(result, false);
+
+      await teardownTestContext(contextWithoutGovernor);
+    });
+
+    it('should return false when no old proposals found', async () => {
+      const result = await strategy.detectAndProcess({
+        context: testContext,
+        client: mockClient as PublicClient,
+        blockNumber: BigInt(25000)
+      });
+
+      assert.equal(result, false);
+      assert.equal(mockClient.multicall.mock.callCount(), 0);
+    });
+
+    it('should handle multicall errors gracefully', async () => {
+      const { db } = testContext.dbContext;
+
+      const currentBlock = BigInt(25000);
+      const oneWeekAgoBlock = currentBlock - BigInt(20160);
+
+      // Create Account first
+      await db('Account').insert({
+        id: '0x0000000000000000000000000000000000000001'
+      });
+
+      // Insert old proposal
+      await db<Proposal>('Proposal').insert({
+        id: 'prop1',
+        proposalId: '1',
+        rawState: ProposalState.Succeeded,
+        state: 'Succeeded',
+        createdAtBlock: oneWeekAgoBlock - BigInt(100),
+        voteStart: BigInt(0),
+        voteEnd: BigInt(0),
+        votesFor: BigInt(0),
+        votesAgainst: BigInt(0),
+        votesAbstains: BigInt(0),
+        quorum: BigInt(0),
+        description: 'Old proposal',
+        createdAt: BigInt(0),
+        signatures: [],
+        targets: [],
+        values: [],
+        calldatas: [],
+        proposer: '0x0000000000000000000000000000000000000001'
+      } as any);
+
+      // Mock multicall to fail
+      mockClient.multicall.mock.mockImplementation(() => Promise.resolve([
+        { status: 'failure', error: new Error('Multicall failed') }
+      ]));
+
+      const result = await strategy.detectAndProcess({
+        context: testContext,
+        client: mockClient as PublicClient,
+        blockNumber: currentBlock
+      });
+
+      // Should not update when multicall fails
+      const unchanged = await db<Proposal>('Proposal').where('id', 'prop1').first();
+      assert.equal(unchanged?.rawState, ProposalState.Succeeded);
+      assert.equal(result, false);
+    });
+  });
+});

--- a/src/watchers/strategies/oldProposalStateStrategy.ts
+++ b/src/watchers/strategies/oldProposalStateStrategy.ts
@@ -1,0 +1,86 @@
+import { ChangeStrategy } from './types';
+import { AppContext } from '../../context/types';
+import { PublicClient } from 'viem';
+import { CONTRACT_NAMES, getContractAddress } from '../../handlers/contracts';
+import log from 'loglevel';
+import { getProposals, updateProposals } from './shared/proposalStateHelpers';
+
+/**
+ * Strategy for checking and updating proposal states for old proposals (older than one week).
+ * Runs periodically (every N blocks) to catch state changes in proposals that are no longer
+ * actively monitored by the recent proposal strategy.
+ */
+const createStrategy = (): ChangeStrategy => {
+  let LAST_OLD_PROPOSALS_CHECK_BLOCK = 0n;
+
+  const detectAndProcess = async (params: {
+    context: AppContext;
+    client: PublicClient;
+    blockNumber: bigint | null;
+  }): Promise<boolean> => {
+    const { context, client, blockNumber } = params;
+    const { dbContext } = context;
+    
+    if (!blockNumber) {
+      log.debug('oldProposalStateStrategy->detectAndProcess: No block number provided, skipping processing');
+      return false;
+    }
+
+    // Get governance contract address from config
+    const governanceAddress = getContractAddress(context.config, CONTRACT_NAMES.GOVERNOR);
+    if (!governanceAddress) {
+      log.error('oldProposalStateStrategy: Governance contract address not configured');
+      return false;
+    }
+
+    const oldProposalCheckIntervalBlocks = BigInt(
+      context.config.blockchain.oldProposalCheckIntervalBlocks ?? 15
+    );
+    const blocksPerWeek = BigInt(context.config.blockchain.blocksPerWeek ?? 20160);
+
+    // Check if we should run the old proposals check based on interval
+    const shouldCheckOldProposals = LAST_OLD_PROPOSALS_CHECK_BLOCK === 0n ||
+      blockNumber >= (LAST_OLD_PROPOSALS_CHECK_BLOCK + oldProposalCheckIntervalBlocks);
+
+    if (!shouldCheckOldProposals) {
+      return false;
+    }
+
+    // Calculate one week ago in blocks
+    const oneWeekAgoBlock = blockNumber - blocksPerWeek;
+    
+    // Get old proposals (created before one week ago)
+    const oldProposals = await getProposals(dbContext, {
+      maxAgeBlock: oneWeekAgoBlock
+    });
+
+    if (oldProposals.length === 0) {
+      LAST_OLD_PROPOSALS_CHECK_BLOCK = blockNumber;
+      log.debug(`oldProposalStateStrategy: No old proposals to check (created before block ${oneWeekAgoBlock.toString()})`);
+      return false;
+    }
+
+    log.info(`oldProposalStateStrategy: Checking ${oldProposals.length} old proposals (created before block ${oneWeekAgoBlock.toString()})`);
+
+    const updatedCount = await updateProposals(
+      oldProposals,
+      client,
+      governanceAddress,
+      dbContext,
+      blockNumber
+    );
+
+    LAST_OLD_PROPOSALS_CHECK_BLOCK = blockNumber;
+    log.debug(`oldProposalStateStrategy: Next check will be at block ${(blockNumber + oldProposalCheckIntervalBlocks).toString()}`);
+
+    return updatedCount > 0;
+  };
+
+  return {
+    name: 'OldProposalState',
+    detectAndProcess
+  };
+};
+
+export const createOldProposalStateStrategy = () => createStrategy();
+

--- a/src/watchers/strategies/shared/proposalStateHelpers.ts
+++ b/src/watchers/strategies/shared/proposalStateHelpers.ts
@@ -1,0 +1,157 @@
+import { Address, PublicClient } from 'viem';
+import { DatabaseContext } from '../../../context/db';
+import { GovernanceAbi } from '../../../abis/GovernanceAbi';
+import log from 'loglevel';
+import { Proposal } from '../types';
+
+export enum ProposalState {
+  Pending,
+  Active,
+  Canceled,
+  Defeated,
+  Succeeded,
+  Queued,
+  Expired,
+  Executed,
+}
+
+export interface GetProposalsOptions {
+  maxAgeBlock?: bigint;
+}
+
+/**
+ * Gets proposals from the database that are in pending states.
+ * Optionally filters by age (createdAtBlock < maxAgeBlock).
+ */
+export const getProposals = async (
+  dbContext: DatabaseContext,
+  options?: GetProposalsOptions
+): Promise<Proposal[]> => {
+  const { db } = dbContext;
+  const pendingStates = [
+    ProposalState.Succeeded, 
+    ProposalState.Queued
+  ];
+
+  let query = db<Proposal>('Proposal').whereIn('rawState', pendingStates);
+
+  if (options?.maxAgeBlock !== undefined) {
+    query = query.where('createdAtBlock', '<', options.maxAgeBlock.toString());
+  }
+
+  return query;
+};
+
+/**
+ * Fetches proposal states from the blockchain via multicall.
+ */
+export const getProposalStatesViaMulticall = async (
+  client: PublicClient,
+  governanceAddress: string,
+  proposalIds: string[]
+): Promise<Map<string, number>> => {
+  const stateMap = new Map<string, number>();
+  
+  if (proposalIds.length === 0) {
+    return stateMap;
+  }
+
+  try {
+    // Create multicall calls for each proposal's state
+    const calls = proposalIds.map(proposalId => ({
+      address: governanceAddress as Address,
+      abi: GovernanceAbi,
+      functionName: 'state',
+      args: [BigInt(proposalId)] as const,
+    }));
+
+    // Execute multicall
+    const results = await client.multicall({
+      contracts: calls,
+    } as any);
+
+    // Map results back to proposal IDs
+    proposalIds.forEach((proposalId, index) => {
+      const result = results[index];
+      if (!result) {
+        log.warn(`No result returned for proposal ${proposalId} at index ${index} (expected ${proposalIds.length} results, got ${results.length})`);
+        return;
+      }
+      if (result.status === 'success') {
+        stateMap.set(proposalId, Number(result.result));
+      } else {
+        log.warn(`Failed to get state for proposal ${proposalId}: ${result.error}`);
+      }
+    });
+
+  } catch (error) {
+    log.error('Error executing multicall for proposal states:', error);
+  }
+
+  return stateMap;
+};
+
+const stateDescriptions: Record<ProposalState, string> = {
+  [ProposalState.Pending]: 'Pending',
+  [ProposalState.Active]: 'Active',
+  [ProposalState.Canceled]: 'Canceled',
+  [ProposalState.Defeated]: 'Defeated',
+  [ProposalState.Succeeded]: 'Succeeded',
+  [ProposalState.Queued]: 'Queued',
+  [ProposalState.Expired]: 'Expired',
+  [ProposalState.Executed]: 'Executed',
+};
+
+/**
+ * Converts a raw proposal state number to its string description.
+ */
+export const getStateDescription = (rawState: ProposalState): string => {
+  return stateDescriptions[rawState] ?? 'Unknown';
+};
+
+/**
+ * Updates proposals in the database with their current blockchain state.
+ * Returns the number of proposals that were updated.
+ */
+export const updateProposals = async (
+  proposals: Proposal[],
+  client: PublicClient,
+  governanceAddress: string,
+  dbContext: DatabaseContext,
+  blockNumber: bigint | null
+): Promise<number> => {
+  if (proposals.length === 0) {
+    return 0;
+  }
+
+  const { db } = dbContext;
+  const proposalIds = proposals.map(p => p.proposalId);
+  
+  // Get real-time states from blockchain via multicall
+  const stateMap = await getProposalStatesViaMulticall(client, governanceAddress, proposalIds);
+  
+  let updatedCount = 0;
+  for (const proposal of proposals) {
+    const { id, rawState } = proposal;
+    const blockchainState = stateMap.get(proposal.proposalId);
+    
+    if (blockchainState !== undefined && blockchainState !== rawState) {
+      const stateDescription = getStateDescription(blockchainState);
+      
+      await db<Proposal>('Proposal').where('id', id).update({
+        rawState: blockchainState,
+        state: stateDescription,
+      });
+      
+      log.debug(`Updated proposal ${id} state from ${rawState} to ${blockchainState} (${stateDescription})`);
+      updatedCount++;
+    }
+  }
+
+  if (updatedCount > 0) {
+    log.info(`Updated ${updatedCount} proposals in block ${blockNumber}`);
+  }
+
+  return updatedCount;
+};
+

--- a/src/watchers/strategies/shared/proposalStateHelpers.ts
+++ b/src/watchers/strategies/shared/proposalStateHelpers.ts
@@ -68,7 +68,7 @@ export const getProposalStatesViaMulticall = async (
     // Execute multicall
     const results = await client.multicall({
       contracts: calls,
-    } as any);
+    });
 
     // Map results back to proposal IDs
     proposalIds.forEach((proposalId, index) => {


### PR DESCRIPTION
# Old Proposal State Strategy

## Overview

This PR implements a new strategy to monitor and update the state of proposals that are more than one week old. Previously, proposals older than a week were not being checked for state changes, which could lead to stale data in the database.

## Problem Statement

The current system only monitors recent proposals. When a proposal that is more than a week old changes state (e.g., from `Succeeded` to `Queued`), these changes were never detected or updated in the database. This could result in outdated proposal states being served to clients.

## Solution

Implemented `oldProposalStateStrategy` that:

- **Periodically checks old proposals**: Runs every 15 blocks (~7.5 minutes at 30s/block) to query proposals older than one week
- **Filters by pending states**: Only monitors proposals in pending states (`Succeeded`, `Queued`) that can still change - excludes `Failed`, `Cancelled`, and `Executed` proposals
- **Efficient blockchain queries**: Uses multicall to batch fetch proposal states from the blockchain
- **Automatic updates**: Updates the database when state changes are detected

## Key Features

### Configuration

Added two new configuration options:

```yaml
blockchain:
  oldProposalCheckIntervalBlocks: 15  # ~7.5 minutes at 30s/block
  blocksPerWeek: 20160  # 7 days * 24h * 3600s / 30s per block
```

Both values are configurable and have sensible defaults.

### Implementation Details

- **Strategy Pattern**: Follows the existing `ChangeStrategy` pattern used by other watchers
- **Interval-based Execution**: Tracks the last check block and only runs when the configured interval is met
- **Shared Helpers**: Extracted reusable functions in `proposalStateHelpers.ts` for:
  - Querying proposals from the database
  - Fetching proposal states via multicall
  - Updating proposals in the database
- **Error Handling**: Gracefully handles missing configuration, null block numbers, and multicall failures

### Testing

Comprehensive integration test suite (`oldProposalStateStrategy.test.ts`) with 817 lines covering:

- Interval-based checking logic
- Old proposal filtering (age-based)
- Multiple proposal processing
- Configuration usage (defaults and custom values)
- Error handling scenarios
- Boundary conditions (exactly one week old proposals)

Tests use a real database connection for authentic integration testing.

## Configuration Notes

- Default interval: 15 blocks (~7.5 minutes)
- Default blocks per week: 20160 (calculated for 30s block time)
- Both values can be customized per environment via config files